### PR TITLE
Expose tunnel interface on the `Device` struct

### DIFF
--- a/boringtun/src/device/mod.rs
+++ b/boringtun/src/device/mod.rs
@@ -1063,4 +1063,8 @@ impl Device {
         )?;
         Ok(())
     }
+
+    pub fn iface(&self) -> &TunSocket {
+        &self.iface
+    }
 }


### PR DESCRIPTION
Hi, I'm working on force-closing the TCP connection in libtelio upon the VPN server change.
This functionality requires crafting packets and injecting them directly into the tunnel, so I must expose the interface.