### PR TITLE
LLT-4509 Bump ring to 0.17.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "untrusted 0.9.0",
+ "untrusted",
  "x25519-dalek",
 ]
 
@@ -927,17 +927,16 @@ checksum = "56d84fdd47036b038fc80dd333d10b6aab10d5d31f4a366e20014def75328d33"
 
 [[package]]
 name = "ring"
-version = "0.16.20"
+version = "0.17.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+checksum = "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b"
 dependencies = [
  "cc",
+ "getrandom",
  "libc",
- "once_cell",
  "spin",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
+ "untrusted",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1050,9 +1049,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.5.2"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "strsim"
@@ -1291,12 +1290,6 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/boringtun/Cargo.toml
+++ b/boringtun/Cargo.toml
@@ -20,7 +20,7 @@ parking_lot = "0.12"
 tracing = "0.1.29"
 ip_network = "0.4.1"
 ip_network_table = "0.2.0"
-ring = "0.16"
+ring = "0.17.5"
 x25519-dalek = { version = "2.0.0-pre.1", features = ["reusable_secrets", "static_secrets"] }
 rand_core = { version = "0.6.3", features = ["getrandom"] }
 chacha20poly1305 = "0.10.0-pre.1"


### PR DESCRIPTION
Bumping `ring` to 0.17.15 version, which supports windows arm64 build.