### PR TITLE
LLT-4613: Boringtun performs spurious rekeying

### DIFF
--- a/boringtun/src/noise/timers.rs
+++ b/boringtun/src/noise/timers.rs
@@ -119,6 +119,8 @@ impl TunnInner {
             TimeLastPacketReceived => {
                 self.timers.want_keepalive = true;
                 self.timers.want_handshake_since = None;
+                // This timer is never read
+                return;
             }
             TimeLastPacketSent => {
                 self.timers.want_keepalive = false;

--- a/boringtun/src/noise/timers.rs
+++ b/boringtun/src/noise/timers.rs
@@ -62,8 +62,8 @@ pub struct Timers {
     pub(super) session_timers: [Duration; super::N_SESSIONS],
     /// Did we receive data without sending anything back?
     want_keepalive: bool,
-    /// Did we send data without hearing back?
-    want_handshake: bool,
+    /// How long ago did we send data without hearing back?
+    want_handshake_since: Option<Duration>,
     persistent_keepalive: usize,
     /// Should this timer call reset rr function (if not a shared rr instance)
     pub(super) should_reset_rr: bool,
@@ -77,7 +77,7 @@ impl Timers {
             timers: Default::default(),
             session_timers: Default::default(),
             want_keepalive: Default::default(),
-            want_handshake: Default::default(),
+            want_handshake_since: Default::default(),
             persistent_keepalive: usize::from(persistent_keepalive.unwrap_or(0)),
             should_reset_rr: reset_rr,
         }
@@ -94,7 +94,7 @@ impl Timers {
         for t in &mut self.timers[..] {
             *t = now;
         }
-        self.want_handshake = false;
+        self.want_handshake_since = None;
         self.want_keepalive = false;
     }
 }
@@ -114,19 +114,21 @@ impl IndexMut<TimerName> for Timers {
 
 impl TunnInner {
     pub(super) fn timer_tick(&mut self, timer_name: TimerName) {
+        let time = self.timers[TimeCurrent];
         match timer_name {
             TimeLastPacketReceived => {
                 self.timers.want_keepalive = true;
-                self.timers.want_handshake = false;
+                self.timers.want_handshake_since = None;
             }
             TimeLastPacketSent => {
-                self.timers.want_handshake = true;
                 self.timers.want_keepalive = false;
+            }
+            TimeLastDataPacketSent => {
+                self.timers.want_handshake_since.get_or_insert(time);
             }
             _ => {}
         }
 
-        let time = self.timers[TimeCurrent];
         if time.is_zero() {
             self.timers[timer_name] = Duration::from_millis(1);
         } else {
@@ -193,7 +195,6 @@ impl TunnInner {
         // Load timers only once:
         let session_established = self.timers[TimeSessionEstablished];
         let handshake_started = self.timers[TimeLastHandshakeStarted];
-        let aut_packet_received = self.timers[TimeLastPacketReceived];
         let aut_packet_sent = self.timers[TimeLastPacketSent];
         let data_packet_received = self.timers[TimeLastDataPacketReceived];
         let data_packet_sent = self.timers[TimeLastDataPacketSent];
@@ -273,15 +274,20 @@ impl TunnInner {
                     }
                 }
 
-                // If we have sent a packet to a given peer but have not received a
+                // If we have sent a data packet to a given peer but have not received a
                 // packet after from that peer for (KEEPALIVE + REKEY_TIMEOUT) ms,
                 // we initiate a new handshake.
-                if data_packet_sent > aut_packet_received
-                    && now - aut_packet_received >= KEEPALIVE_TIMEOUT + REKEY_TIMEOUT
-                    && mem::replace(&mut self.timers.want_handshake, false)
+                if self
+                    .timers
+                    .want_handshake_since
+                    .map(|want_handshake_since| {
+                        (now - want_handshake_since) >= (KEEPALIVE_TIMEOUT + REKEY_TIMEOUT)
+                    })
+                    .unwrap_or_default()
                 {
                     tracing::warn!("HANDSHAKE(KEEPALIVE + REKEY_TIMEOUT)");
                     handshake_initiation_required = true;
+                    self.timers.want_handshake_since = None;
                 }
 
                 if !handshake_initiation_required {


### PR DESCRIPTION
**Problem**

Situation in which bug was reproduced:
```mermaid

sequenceDiagram
    autonumber
    Initiator->>Responder: Handshake Initiation
    Responder->>Initiator: Handshake Response
    Note over Initiator,Responder: Some time passes
    Responder->>Initiator: Keepalive
    activate Initiator
    Note over Initiator,Responder: 'Rekey-Timeout' + ε seconds passes
    Initiator->>Responder: Non empty data packet<br/>for which there will be no response
    activate Responder
    Note right of Responder: Start a timer for 'Keepalive-Timeout'<br/>to send reply with keepalive packet<br/>if no other packet will be sent
    
    Initiator->>Responder: Handshake Initiation
    deactivate Initiator
    Note left of Initiator: It's 'Rekey-Timeout' + 'Keepalive-Timeout'<br/>since we last received from Responder (3).<br/>Responder would have sent keepalive in 8
    Responder-->Responder: Cancel timer
    deactivate Responder
    Responder->>Initiator: Handshake Response
    Responder-->Initiator: Keepalive would have been sent here, after<br/> 'Keepalive-Timeout' from 4
```
The problem is that for the purpose of deciding if handshake should be sent, we tracked time since the last received packet (point 3 above) from the responder. Which is not correct since the spec allows for arbitrary long durations of silence if there are no data packets exchanged (time between 3 and 4 above). See [section 6.5](https://www.wireguard.com/papers/wireguard.pdf#section.6). 

This matches also the kernel implementation, which starts a new timer for the **first** data message **after** a keepalive (which turns off current timer if any) - time 4 in our example.

In `wg_packet_create_data_done` [we can see](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/net/wireguard/send.c?h=v6.6.4#n242) that `wg_timers_data_sent` is called only for data packets:
```c
static void wg_packet_create_data_done(struct wg_peer *peer, struct sk_buff *first)
{
	[...]
	if (likely(data_sent))
		wg_timers_data_sent(peer);
	[...]
}
```
And in `wg_timers_data_sent` [we see](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/net/wireguard/timers.c?h=v6.6.4#n144) that it's starting a timer only if one is not already started:
```c
/* Should be called after an authenticated data packet is sent. */
void wg_timers_data_sent(struct wg_peer *peer)
{
	if (!timer_pending(&peer->timer_new_handshake))
		mod_peer_timer(peer, &peer->timer_new_handshake,
			jiffies + (KEEPALIVE_TIMEOUT + REKEY_TIMEOUT) * HZ +
			get_random_u32_below(REKEY_TIMEOUT_JITTER_MAX_JIFFIES));
}
```
Finally in `wg_timers_any_authenticated_packet_received` [we see](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/net/wireguard/timers.c?h=v6.6.4#n173) that it is canceled:
```c
/* Should be called after any type of authenticated packet is received, whether
 * keepalive, data, or handshake.
 */
void wg_timers_any_authenticated_packet_received(struct wg_peer *peer)
{
	del_timer(&peer->timer_new_handshake);
}
```
Those are the only places where `timer_new_handshake` is modified.

**Solution**:

We now track the time since 4 in the above example - the oldest data message after which we didn't receive any packet from responder.