### PR TITLE
Make sure that when we subtract durations we don't overflow

### DIFF
--- a/boringtun/src/noise/timers.rs
+++ b/boringtun/src/noise/timers.rs
@@ -283,7 +283,8 @@ impl TunnInner {
                     .timers
                     .want_handshake_since
                     .map(|want_handshake_since| {
-                        (now - want_handshake_since) >= (KEEPALIVE_TIMEOUT + REKEY_TIMEOUT)
+                        (now.saturating_sub(want_handshake_since))
+                            >= (KEEPALIVE_TIMEOUT + REKEY_TIMEOUT)
                     })
                     .unwrap_or_default()
                 {


### PR DESCRIPTION
Some failures had been seen on nightly runs of libtelio:

```
------------------------------Captured stdout call------------------------------ 
[alpha]: stdout: - started telio with BoringTun:4OYyz9lKdQj6VC9OhO8/zRlQzRPGNqycrE8jxEg8M0c=...
[beta]: stdout: - started telio with BoringTun:0EU5Uzr7oX6FHsCZmx3VVKS4mxsUecumX/HCDsFncXU=...
[alpha]: stderr: thread '<unnamed>' panicked at 'overflow when subtracting durations', library/core/src/time.rs:930:31
[alpha]: stderr: note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Suspected source of this is the recently changed (#8) mechanism around sending handshake. In parallel `RUST_BACKTRACE` was added to the nat-lab in libtelio CI. 