### PR TITLE
Enable github workflow for all branches

### DIFF
--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -1,10 +1,6 @@
 name: PR Status Checks
 
-on:
-  push:
-    branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
+on: [push, pull_request]
 
 jobs:
   # Depends on all actions that are required for a "successful" CI run.

--- a/boringtun-cli/src/main.rs
+++ b/boringtun-cli/src/main.rs
@@ -8,6 +8,7 @@ use daemonize::Daemonize;
 use std::fs::File;
 use std::os::unix::net::UnixDatagram;
 use std::process::exit;
+use std::sync::Arc;
 use tracing::Level;
 
 fn check_tun_name(_v: String) -> Result<(), String> {
@@ -151,6 +152,10 @@ fn main() {
         use_connected_socket: !matches.is_present("disable-connected-udp"),
         #[cfg(target_os = "linux")]
         use_multi_queue: !matches.is_present("disable-multi-queue"),
+        open_uapi_socket: false,
+        protect: Arc::new(boringtun::device::MakeExternalBoringtunNoop),
+        firewall_process_inbound_callback: None,
+        firewall_process_outbound_callback: None,
     };
 
     let mut device_handle: DeviceHandle = match DeviceHandle::new(tun_name, config) {

--- a/boringtun/src/device/integration_tests/mod.rs
+++ b/boringtun/src/device/integration_tests/mod.rs
@@ -268,9 +268,12 @@ mod tests {
                     use_connected_socket: true,
                     #[cfg(target_os = "linux")]
                     use_multi_queue: true,
-                    open_uapi_socket: false,
+                    open_uapi_socket: true,
                     #[cfg(target_os = "linux")]
                     uapi_fd: -1,
+                    protect: Arc::new(crate::device::MakeExternalBoringtunNoop),
+                    firewall_process_inbound_callback: None,
+                    firewall_process_outbound_callback: None,
                 },
             )
         }
@@ -487,14 +490,14 @@ mod tests {
         let wg = WGHandle::init("192.0.2.0".parse().unwrap(), "::2".parse().unwrap());
         assert!(wg.wg_get().ends_with("errno=0\n\n"));
         assert_eq!(wg.wg_set_port(port), "errno=0\n\n");
-        assert_eq!(wg.wg_set_key(private_key), "errno=0\n\n");
+        assert_eq!(wg.wg_set_key(private_key.clone()), "errno=0\n\n");
 
         // Check that the response matches what we expect
         assert_eq!(
             wg.wg_get(),
             format!(
-                "own_public_key={}\nlisten_port={}\nerrno=0\n\n",
-                encode(own_public_key.as_bytes()),
+                "private_key={}\nlisten_port={}\nerrno=0\n\n",
+                encode(private_key.as_bytes()),
                 port
             )
         );
@@ -522,7 +525,7 @@ mod tests {
         assert_eq!(
             wg.wg_get(),
             format!(
-                "own_public_key={}\n\
+                "private_key={}\n\
                  listen_port={}\n\
                  public_key={}\n\
                  endpoint={}\n\
@@ -531,7 +534,7 @@ mod tests {
                  rx_bytes=0\n\
                  tx_bytes=0\n\
                  errno=0\n\n",
-                encode(own_public_key.as_bytes()),
+                encode(private_key.as_bytes()),
                 port,
                 encode(peer_pub_key.as_bytes()),
                 endpoint,
@@ -561,9 +564,12 @@ mod tests {
                 use_connected_socket: false,
                 #[cfg(target_os = "linux")]
                 use_multi_queue: true,
-                open_uapi_socket: false,
+                open_uapi_socket: true,
                 #[cfg(target_os = "linux")]
                 uapi_fd: -1,
+                protect: Arc::new(crate::device::MakeExternalBoringtunNoop),
+                firewall_process_inbound_callback: None,
+                firewall_process_outbound_callback: None,
             },
         );
 
@@ -720,9 +726,12 @@ mod tests {
                 use_connected_socket: false,
                 #[cfg(target_os = "linux")]
                 use_multi_queue: true,
-                open_uapi_socket: false,
+                open_uapi_socket: true,
                 #[cfg(target_os = "linux")]
                 uapi_fd: -1,
+                protect: Arc::new(crate::device::MakeExternalBoringtunNoop),
+                firewall_process_inbound_callback: None,
+                firewall_process_outbound_callback: None,
             },
         );
 

--- a/boringtun/src/device/mod.rs
+++ b/boringtun/src/device/mod.rs
@@ -109,6 +109,12 @@ pub trait MakeExternalBoringtun: Send + Sync {
     fn make_external(&self, socket: RawFd);
 }
 
+pub struct MakeExternalBoringtunNoop;
+
+impl MakeExternalBoringtun for MakeExternalBoringtunNoop {
+    fn make_external(&self, _socket: std::os::fd::RawFd) {}
+}
+
 pub struct DeviceHandle {
     pub device: Arc<Lock<Device>>, // The interface this handle owns
     threads: Vec<JoinHandle<()>>,


### PR DESCRIPTION
Integration tests require access to the uapi socket, so for them it is enabled.

Changed the expected key from public to private because we did make this change in e313758ce9f012db2cef1c52227370b7bd98c857.