### PR TITLE
Use saturating duration in timers.rs

### DIFF
--- a/boringtun/src/noise/mod.rs
+++ b/boringtun/src/noise/mod.rs
@@ -4,6 +4,7 @@
 pub mod errors;
 pub mod handshake;
 pub mod rate_limiter;
+pub mod safe_duration;
 
 mod session;
 mod timers;

--- a/boringtun/src/noise/safe_duration.rs
+++ b/boringtun/src/noise/safe_duration.rs
@@ -1,0 +1,79 @@
+use std::{
+    ops::{Add, Mul, Sub},
+    time::Duration,
+};
+
+#[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+pub struct SafeDuration(Duration);
+
+impl SafeDuration {
+    pub const fn from_secs(secs: u64) -> Self {
+        Self(Duration::from_secs(secs))
+    }
+
+    pub const fn is_zero(&self) -> bool {
+        self.0.is_zero()
+    }
+
+    pub const fn checked_sub(&self, rhs: SafeDuration) -> Option<Duration> {
+        self.0.checked_sub(rhs.0)
+    }
+
+    pub const fn from_millis(millis: u64) -> SafeDuration {
+        Self(Duration::from_millis(millis))
+    }
+}
+
+impl Add for SafeDuration {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self(self.0.saturating_add(rhs.0))
+    }
+}
+
+impl Sub for SafeDuration {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self(self.0.saturating_sub(rhs.0))
+    }
+}
+
+impl Mul<u32> for SafeDuration {
+    type Output = Self;
+
+    fn mul(self, rhs: u32) -> Self::Output {
+        Self(self.0.saturating_mul(rhs))
+    }
+}
+
+impl PartialEq<Duration> for SafeDuration {
+    fn eq(&self, other: &Duration) -> bool {
+        self.0.eq(other)
+    }
+}
+
+impl PartialOrd<Duration> for SafeDuration {
+    fn partial_cmp(&self, other: &Duration) -> Option<std::cmp::Ordering> {
+        self.0.partial_cmp(other)
+    }
+}
+
+impl PartialEq<SafeDuration> for Duration {
+    fn eq(&self, other: &SafeDuration) -> bool {
+        self.eq(&other.0)
+    }
+}
+
+impl PartialOrd<SafeDuration> for Duration {
+    fn partial_cmp(&self, other: &SafeDuration) -> Option<std::cmp::Ordering> {
+        self.partial_cmp(&other.0)
+    }
+}
+
+impl From<Duration> for SafeDuration {
+    fn from(value: Duration) -> Self {
+        Self(value)
+    }
+}

--- a/boringtun/src/noise/timers.rs
+++ b/boringtun/src/noise/timers.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 use super::errors::WireGuardError;
-use crate::noise::{TunnInner, TunnResult};
+use crate::noise::{safe_duration::SafeDuration, TunnInner, TunnResult};
 use std::mem;
 use std::ops::{Index, IndexMut};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 #[cfg(not(any(target_os = "android", target_os = "ios", target_os = "tvos")))]
 use std::time::Instant;
@@ -20,12 +20,12 @@ use _instant_boottime::Instant;
 
 // Some constants, represent time in seconds
 // https://www.wireguard.com/papers/wireguard.pdf#page=14
-const REKEY_AFTER_TIME: Duration = Duration::from_secs(120);
-const REJECT_AFTER_TIME: Duration = Duration::from_secs(180);
-const REKEY_ATTEMPT_TIME: Duration = Duration::from_secs(90);
-const REKEY_TIMEOUT: Duration = Duration::from_secs(5);
-const KEEPALIVE_TIMEOUT: Duration = Duration::from_secs(10);
-const COOKIE_EXPIRATION_TIME: Duration = Duration::from_secs(120);
+const REKEY_AFTER_TIME: SafeDuration = SafeDuration::from_secs(120);
+const REJECT_AFTER_TIME: SafeDuration = SafeDuration::from_secs(180);
+const REKEY_ATTEMPT_TIME: SafeDuration = SafeDuration::from_secs(90);
+const REKEY_TIMEOUT: SafeDuration = SafeDuration::from_secs(5);
+const KEEPALIVE_TIMEOUT: SafeDuration = SafeDuration::from_secs(10);
+const COOKIE_EXPIRATION_TIME: SafeDuration = SafeDuration::from_secs(120);
 
 #[derive(Debug)]
 pub enum TimerName {
@@ -58,12 +58,12 @@ pub struct Timers {
     is_initiator: bool,
     /// Start time of the tunnel
     time_started: Instant,
-    timers: [Duration; TimerName::Top as usize],
-    pub(super) session_timers: [Duration; super::N_SESSIONS],
+    timers: [SafeDuration; TimerName::Top as usize],
+    pub(super) session_timers: [SafeDuration; super::N_SESSIONS],
     /// Did we receive data without sending anything back?
     want_keepalive: bool,
     /// How long ago did we send data without hearing back?
-    want_handshake_since: Option<Duration>,
+    want_handshake_since: Option<SafeDuration>,
     persistent_keepalive: usize,
     /// Should this timer call reset rr function (if not a shared rr instance)
     pub(super) should_reset_rr: bool,
@@ -90,7 +90,7 @@ impl Timers {
     // We don't really clear the timers, but we set them to the current time to
     // so the reference time frame is the same
     pub(super) fn clear(&mut self) {
-        let now = Instant::now().duration_since(self.time_started);
+        let now = Instant::now().duration_since(self.time_started).into();
         for t in &mut self.timers[..] {
             *t = now;
         }
@@ -100,14 +100,14 @@ impl Timers {
 }
 
 impl Index<TimerName> for Timers {
-    type Output = Duration;
-    fn index(&self, index: TimerName) -> &Duration {
+    type Output = SafeDuration;
+    fn index(&self, index: TimerName) -> &SafeDuration {
         &self.timers[index as usize]
     }
 }
 
 impl IndexMut<TimerName> for Timers {
-    fn index_mut(&mut self, index: TimerName) -> &mut Duration {
+    fn index_mut(&mut self, index: TimerName) -> &mut SafeDuration {
         &mut self.timers[index as usize]
     }
 }
@@ -132,7 +132,7 @@ impl TunnInner {
         }
 
         if time.is_zero() {
-            self.timers[timer_name] = Duration::from_millis(1);
+            self.timers[timer_name] = SafeDuration::from_millis(1);
         } else {
             self.timers[timer_name] = time;
         }
@@ -161,7 +161,7 @@ impl TunnInner {
         self.timers.clear();
     }
 
-    fn update_session_timers(&mut self, time_now: Duration) {
+    fn update_session_timers(&mut self, time_now: SafeDuration) {
         let timers = &mut self.timers;
 
         for (i, t) in timers.session_timers.iter_mut().enumerate() {
@@ -189,7 +189,7 @@ impl TunnInner {
 
         // All the times are counted from tunnel initiation, for efficiency our timers are rounded
         // to a second, as there is no real benefit to having highly accurate timers.
-        let now = time.duration_since(self.timers.time_started);
+        let now = time.duration_since(self.timers.time_started).into();
         self.timers[TimeCurrent] = now;
 
         self.update_session_timers(now);
@@ -283,8 +283,7 @@ impl TunnInner {
                     .timers
                     .want_handshake_since
                     .map(|want_handshake_since| {
-                        (now.saturating_sub(want_handshake_since))
-                            >= (KEEPALIVE_TIMEOUT + REKEY_TIMEOUT)
+                        (now - want_handshake_since) >= (KEEPALIVE_TIMEOUT + REKEY_TIMEOUT)
                     })
                     .unwrap_or_default()
                 {
@@ -307,7 +306,7 @@ impl TunnInner {
                     // Persistent KEEPALIVE
                     if persistent_keepalive > 0
                         && ((now - self.timers[TimePersistentKeepalive]
-                            >= Duration::from_secs(persistent_keepalive as _))
+                            >= SafeDuration::from_secs(persistent_keepalive as _))
                             || self.time_since_last_handshake().is_none())
                     {
                         tracing::debug!("KEEPALIVE(PERSISTENT_KEEPALIVE)");
@@ -329,12 +328,15 @@ impl TunnInner {
         TunnResult::Done
     }
 
-    pub(super) fn time_since_last_handshake(&self) -> Option<Duration> {
+    pub(super) fn time_since_last_handshake(&self) -> Option<std::time::Duration> {
         let current_session = self.current;
         if self.sessions[current_session % super::N_SESSIONS].is_some() {
-            let time_current = Instant::now().duration_since(self.timers.time_started);
+            let time_current: SafeDuration = Instant::now()
+                .duration_since(self.timers.time_started)
+                .into();
             let time_session_established = self.timers[TimeSessionEstablished];
-            let epoch_time = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+            let epoch_time: SafeDuration =
+                SystemTime::now().duration_since(UNIX_EPOCH).unwrap().into();
 
             if time_session_established.is_zero() {
                 None


### PR DESCRIPTION
When running libtelio CI, it was found that sometimes early in the startup, boringtun panics:

```
[2024-01-02 00:39:32] [alpha]: stderr: thread '<unnamed>' panicked at 'overflow when subtracting durations', library/core/src/time.rs:930:31
[2024-01-02 00:39:32] [alpha]: stderr: stack backtrace:
[2024-01-02 00:39:32] [alpha]: stderr:    0:     0x55a5c239bf11 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::hdaa196410d9ee0b9
[2024-01-02 00:39:32] [alpha]: stderr:    1:     0x55a5c23ccb2f - core::fmt::write::h66b3c629f3d623e4
[2024-01-02 00:39:32] [alpha]: stderr:    2:     0x55a5c23972a7 - std::io::Write::write_fmt::hb6d80fba4115e0c2
[2024-01-02 00:39:32] [alpha]: stderr:    3:     0x55a5c239bd25 - std::sys_common::backtrace::print::hca95c2d0055e42a2
[2024-01-02 00:39:32] [alpha]: stderr:    4:     0x55a5c239d253 - std::panicking::default_hook::{{closure}}::hc03c01c56bca600c
[2024-01-02 00:39:32] [alpha]: stderr:    5:     0x55a5c239cfe4 - std::panicking::default_hook::hb2cb5315b6634f1c
[2024-01-02 00:39:32] [alpha]: stderr:    6:     0x55a5c239d7d9 - std::panicking::rust_panic_with_hook::h75cd912a39a34e8a
[2024-01-02 00:39:32] [alpha]: stderr:    7:     0x55a5c239d6d7 - std::panicking::begin_panic_handler::{{closure}}::h1498b46f7849e167
[2024-01-02 00:39:32] [alpha]: stderr:    8:     0x55a5c239c376 - std::sys_common::backtrace::__rust_end_short_backtrace::hd36a39b27b98086b
[2024-01-02 00:39:32] [alpha]: stderr:    9:     0x55a5c239d422 - rust_begin_unwind
[2024-01-02 00:39:32] [alpha]: stderr:   10:     0x55a5c1723903 - core::panicking::panic_fmt::h98ef273141454c23
[2024-01-02 00:39:32] [alpha]: stderr:   11:     0x55a5c17238c3 - core::option::expect_failed::hf5b9fcba7deab40f
[2024-01-02 00:39:32] [alpha]: stderr:   12:     0x55a5c23d06bd - <core::time::Duration as core::ops::arith::Sub>::sub::hdaba578d3f344094
[2024-01-02 00:39:32] [alpha]: stderr:   13:     0x55a5c226abf5 - boringtun::noise::Tunn::update_timers::hcfdfd2a4df469a3a
[2024-01-02 00:39:32] [alpha]: stderr:   14:     0x55a5c225cd9c - boringtun::device::Device::register_timers::{{closure}}::hbf3cb8bcd3c1b821
[2024-01-02 00:39:32] [alpha]: stderr:   15:     0x55a5c2259e61 - boringtun::device::DeviceHandle::event_loop::h766cfc382d211742
```

To combat this, we will use a wrapper struct `SafeDuration` that will have all public operations be safe and saturating. To make the diff small and make future updates easier, `SafeDuration` is imported as `Duration` in the `timers.rs`.