### PR TITLE
Resolve LLT-5096: Throw uapi error when iface is down

### DIFF
--- a/boringtun/src/device/api.rs
+++ b/boringtun/src/device/api.rs
@@ -149,11 +149,14 @@ pub fn api_exec<R: Read, W: Write>(
     let mut cmd = String::new();
     if reader.read_line(&mut cmd).is_ok() {
         cmd.pop(); // pop the new line character
-        let status = match cmd.as_ref() {
-            // Only two commands are legal according to the protocol, get=1 and set=1.
-            "get=1" => api_get(writer, d),
-            "set=1" => api_set(reader, d),
-            _ => EIO,
+        let status = match d.closed {
+            true => ENOENT,
+            false => match cmd.as_ref() {
+                // Only two commands are legal according to the protocol, get=1 and set=1.
+                "get=1" => api_get(writer, d),
+                "set=1" => api_set(reader, d),
+                _ => EIO,
+            },
         };
         // The protocol requires to return an error code as the response, or zero on success
         writeln!(writer, "errno={}\n", status).ok();

--- a/boringtun/src/device/mod.rs
+++ b/boringtun/src/device/mod.rs
@@ -144,6 +144,7 @@ pub struct Device {
     update_seq: u32,
 
     iface: Arc<TunSocket>,
+    closed: bool,
     udp4: Option<Arc<UDPSocket>>,
     udp6: Option<Arc<UDPSocket>>,
 
@@ -280,6 +281,7 @@ impl DeviceHandle {
                             Action::Continue => {}
                             Action::Yield => break,
                             Action::Exit => {
+                                device_lock.try_writeable(|_| {}, |dev| dev.closed = true);
                                 device_lock.trigger_exit();
                                 return;
                             }
@@ -485,6 +487,7 @@ impl Device {
         let mut device = Device {
             queue: Arc::new(poll),
             iface,
+            closed: false,
             config,
             exit_notice: Default::default(),
             yield_notice: Default::default(),


### PR DESCRIPTION
### Problem
Simillar problem to https://github.com/NordSecurity/libtelio/pull/496, when adapter is dead, there is no indication of it. uapi set/get just returns last know information that is saved in memory.

### Solution
- Add state variable
- Throw uapi error if state is down