### PR TITLE
Fix last_handshake_time values

### DIFF
--- a/boringtun/src/device/api.rs
+++ b/boringtun/src/device/api.rs
@@ -199,9 +199,17 @@ fn api_get<W: Write>(writer: &mut BufWriter<W>, d: &Device) -> i32 {
             writeln!(writer, "allowed_ip={}/{}", addr, cidr);
         }
 
-        if let Some(time) = p.time_since_last_handshake() {
-            writeln!(writer, "last_handshake_time_sec={}", time.as_secs());
-            writeln!(writer, "last_handshake_time_nsec={}", time.subsec_nanos());
+        if let Some(last_handshake_time) = p.last_handshake_time() {
+            writeln!(
+                writer,
+                "last_handshake_time_sec={}",
+                last_handshake_time.as_secs()
+            );
+            writeln!(
+                writer,
+                "last_handshake_time_nsec={}",
+                last_handshake_time.subsec_nanos()
+            );
         }
 
         let (_, tx_bytes, rx_bytes, ..) = p.tunnel.stats();

--- a/boringtun/src/device/peer.rs
+++ b/boringtun/src/device/peer.rs
@@ -182,6 +182,10 @@ impl Peer {
         self.tunnel.time_since_last_handshake()
     }
 
+    pub fn last_handshake_time(&self) -> Option<std::time::Duration> {
+        self.tunnel.last_handshake_time()
+    }
+
     pub fn persistent_keepalive(&self) -> Option<u16> {
         self.tunnel.persistent_keepalive()
     }

--- a/boringtun/src/noise/timers.rs
+++ b/boringtun/src/noise/timers.rs
@@ -5,6 +5,7 @@ use super::errors::WireGuardError;
 use crate::noise::{safe_duration::SafeDuration as Duration, Tunn, TunnResult};
 use std::mem;
 use std::ops::{Index, IndexMut};
+use std::time::SystemTime;
 
 #[cfg(feature = "mock-instant")]
 use mock_instant::Instant;
@@ -353,6 +354,15 @@ impl Tunn {
         } else {
             None
         }
+    }
+
+    pub fn last_handshake_time(&self) -> Option<std::time::Duration> {
+        self.time_since_last_handshake().and_then(|d| {
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .ok()
+                .map(|t| t - d)
+        })
     }
 
     pub fn persistent_keepalive(&self) -> Option<u16> {


### PR DESCRIPTION
Currently the get method called on boringtun UAPI receives not a time of the last handshake in the last_handshake_time_* fields, but time since last handshake, which is not compliant with the wireguard UAPI standard.