### PR TITLE
Fix tunnel breaks the connection when preshared key is changed after 3 mins

### DIFF
--- a/boringtun/src/device/mod.rs
+++ b/boringtun/src/device/mod.rs
@@ -813,7 +813,10 @@ impl Device {
                         .handle_verified_packet(parsed_packet, &mut t.dst_buf[..])
                     {
                         TunnResult::Done => {}
-                        TunnResult::Err(_) => continue,
+                        TunnResult::Err(err) => {
+                            tracing::warn!(message = "Failed to handle packet", error = ?err);
+                            continue;
+                        },
                         TunnResult::WriteToNetwork(packet) => {
                             flush = true;
                             if let Err(err) = udp.send_to(packet, &addr) {

--- a/boringtun/src/noise/handshake.rs
+++ b/boringtun/src/noise/handshake.rs
@@ -479,6 +479,10 @@ impl Handshake {
         self.params.set_static_private(private_key, public_key)
     }
 
+    pub(crate) fn set_preshared_key(&mut self, preshared_key: Option<[u8; 32]>) {
+        self.params.preshared_key = preshared_key;
+    }
+
     pub(super) fn receive_handshake_initialization<'a>(
         &mut self,
         packet: HandshakeInit,

--- a/boringtun/src/noise/mod.rs
+++ b/boringtun/src/noise/mod.rs
@@ -256,6 +256,14 @@ impl Tunn {
         Ok(())
     }
 
+    /// Update the preshared key and clear sessions
+    pub fn set_preshared_key(&mut self, preshared_key: Option<[u8; 32]>) {
+        self.handshake.set_preshared_key(preshared_key);
+        for s in &mut self.sessions {
+            *s = None;
+        }
+    }
+
     /// Encapsulate a single packet from the tunnel interface.
     /// Returns TunnResult.
     ///


### PR DESCRIPTION
The `Peer::set_preshared_key()` does not have any real effect. Thus when the key is changed the tunnel cannot create a new handshake after the 3-minute timeout