### PR TITLE
LLT-5324 Enable performance cores on Apple

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,7 @@ dependencies = [
  "blake2",
  "chacha20poly1305",
  "criterion",
+ "dispatch",
  "etherparse",
  "hex",
  "hmac",
@@ -442,6 +443,11 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "dispatch"
+version = "0.2.0"
+source = "git+https://github.com/NordSecurity/rust-dispatch.git?rev=13447cd7221a74ebcce1277ae0cfc9a421a28ec5#13447cd7221a74ebcce1277ae0cfc9a421a28ec5"
 
 [[package]]
 name = "either"

--- a/boringtun/Cargo.toml
+++ b/boringtun/Cargo.toml
@@ -41,6 +41,9 @@ mock_instant = { version = "0.2", optional = true }
 socket2 = { version = "0.5", features = ["all"], optional = true }
 thiserror = { version = "1", optional = true }
 
+[target.'cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))'.dependencies]
+dispatch = { git = "https://github.com/NordSecurity/rust-dispatch.git", rev = "13447cd7221a74ebcce1277ae0cfc9a421a28ec5" }
+
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.28", default-features = false, features = [
     "time",


### PR DESCRIPTION
Use Apple's Grand Central Dispatch high priority queues, instead of `std::thread` in Apple case. This enables `boringtun` to run on performance core.