### PR TITLE
Fix bad socket creation, bad socket configuration and lock within lock

### DIFF
--- a/boringtun/src/device/integration_tests/mod.rs
+++ b/boringtun/src/device/integration_tests/mod.rs
@@ -482,7 +482,6 @@ mod tests {
     fn test_wireguard_set() {
         let port = next_port();
         let private_key = StaticSecret::random_from_rng(OsRng);
-        let own_public_key = PublicKey::from(&private_key);
 
         let wg = WGHandle::init("192.0.2.0".parse().unwrap(), "::2".parse().unwrap());
         assert!(wg.wg_get().ends_with("errno=0\n\n"));
@@ -635,7 +634,7 @@ mod tests {
     #[ignore]
     fn test_wg_start_ipv4_traffic_flows_after_reject_after_time() {
         let port = next_port();
-        let private_key = StaticSecret::new(OsRng);
+        let private_key = StaticSecret::random_from_rng(OsRng);
         let public_key = PublicKey::from(&private_key);
         let addr_v4 = next_ip();
         let addr_v6 = next_ip_v6();

--- a/boringtun/src/noise/integration_tests/mod.rs
+++ b/boringtun/src/noise/integration_tests/mod.rs
@@ -51,10 +51,10 @@ mod tests {
     }
 
     async fn setup() -> (WGClient, WGClient) {
-        let a_secret_key = StaticSecret::new(&mut rand::rngs::StdRng::from_entropy());
+        let a_secret_key = StaticSecret::random_from_rng(&mut rand::rngs::StdRng::from_entropy());
         let a_public_key = PublicKey::from(&a_secret_key);
 
-        let b_secret_key = StaticSecret::new(&mut rand::rngs::StdRng::from_entropy());
+        let b_secret_key = StaticSecret::random_from_rng(&mut rand::rngs::StdRng::from_entropy());
         let b_public_key = PublicKey::from(&b_secret_key);
 
         let a = WGClient::new(a_secret_key, b_public_key).await;


### PR DESCRIPTION
v0.6.0 introduced bugs due to which traffic became around 50 times slower. This was due to:
Bad socket configuration by Cloudflare.
Bad socket protection on our side.
A lock within a lock on our side.

So all of this is fixed with this PR.

Also added a unit test to validate connected socket creation since the other issues can be easily caught with our current nat-lab tests.

And besides that fixed some older warnings about deprecated functions and unused variables.