### PR TITLE
Fix in and out packets ordering requirements for passive keepalive

### DIFF
--- a/boringtun/src/noise/timers.rs
+++ b/boringtun/src/noise/timers.rs
@@ -309,7 +309,7 @@ impl Tunn {
                 if !handshake_initiation_required {
                     // If a packet has been received from a given peer, but we have not sent one back
                     // to the given peer in KEEPALIVE ms, we send an empty packet.
-                    if data_packet_received > aut_packet_sent
+                    if data_packet_received >= aut_packet_sent
                         && now - aut_packet_sent >= KEEPALIVE_TIMEOUT
                         && mem::replace(&mut self.timers.want_keepalive, false)
                     {


### PR DESCRIPTION
#problem

Most of boringtun timers operation on roughly 4Hz resolution for timers. This is implemented by having [periodic_action](https://github.com/NordSecurity/boringtun/blob/v1.2.4/boringtun/src/device/mod.rs#L753) which occurs with 4Hz frequency. Within the `update_timers()` there is one "special" timer called `TimeCurrent` updated [here](https://github.com/NordSecurity/boringtun/blob/v1.2.4/boringtun/src/noise/timers.rs#L207). Any other timers are updated in this [timer_tick()](https://github.com/NordSecurity/boringtun/blob/v1.2.4/boringtun/src/noise/timers.rs#L148) function, and update is based on `TimeCurrent`, so it means that all other timers from [this](https://github.com/NordSecurity/boringtun/blob/v1.2.4/boringtun/src/noise/timers.rs#L45) list also inherits resolution of 4Hz.

Up until this time, passive keepalive sending logic was requiring strict ordering, such that timestamp for receiving packet must be [strictly higher](https://github.com/NordSecurity/boringtun/blob/v1.2.4/boringtun/src/noise/timers.rs#L312) than timestamp of last authorized packet transmission.

This causes a race condition, where in case, last authorized packet transmission and last data packet reception happens within the same `update_timers()` "window", it would cause `TimeLastPacketSent` exactly equal to `TimeLastDataPacketReceived`. Even if, in reality, packet was received after sending authorized packet. See image below for more exact sequence of events:
![boringtun-ordering-bug](https://github.com/user-attachments/assets/42d75f71-117b-44ec-a542-d68ef2a2abf0)

Above sequence of events causes [this](https://github.com/NordSecurity/boringtun/blob/v1.2.4/boringtun/src/noise/timers.rs#L312) condition to be false and confuses link detection logic.

I have changed the comparison in this PR to allow any ordering of received and sent packets as `want_keepalive` already ensures that transmitted packet happens strictly before received one.